### PR TITLE
Add histogram for insertion time to completion time

### DIFF
--- a/hook-worker/src/worker.rs
+++ b/hook-worker/src/worker.rs
@@ -6,6 +6,7 @@ use chrono::Utc;
 use futures::future::join_all;
 use hook_common::health::HealthHandle;
 use hook_common::pgqueue::PgTransactionBatch;
+use hook_common::webhook;
 use hook_common::{
     pgqueue::{
         DatabaseError, Job, PgQueue, PgQueueJob, PgTransactionJob, RetryError, RetryInvalidError,
@@ -235,15 +236,24 @@ async fn process_webhook_job<W: WebhookJob>(
 
     match send_result {
         Ok(_) => {
-            let insert_to_complete_duration = Utc::now() - webhook_job.job().created_at;
-            metrics::histogram!("webhook_jobs_insert_to_complete_duration_seconds", &labels)
-                .record((insert_to_complete_duration.num_milliseconds() as f64) / 1_000_f64);
+            let created_at = webhook_job.job().created_at;
+            let retries = webhook_job.job().attempt - 1;
+            let labels_with_retries = [
+                ("queue", webhook_job.queue()),
+                ("retries", retries.to_string()),
+            ];
 
             webhook_job.complete().await.map_err(|error| {
                 metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
                 error
             })?;
 
+            let insert_to_complete_duration = Utc::now() - created_at;
+            metrics::histogram!(
+                "webhook_jobs_insert_to_complete_duration_seconds",
+                &labels_with_retries
+            )
+            .record((insert_to_complete_duration.num_milliseconds() as f64) / 1_000_f64);
             metrics::counter!("webhook_jobs_completed", &labels).increment(1);
             metrics::histogram!("webhook_jobs_processing_duration_seconds", &labels)
                 .record(elapsed);

--- a/hook-worker/src/worker.rs
+++ b/hook-worker/src/worker.rs
@@ -6,7 +6,6 @@ use chrono::Utc;
 use futures::future::join_all;
 use hook_common::health::HealthHandle;
 use hook_common::pgqueue::PgTransactionBatch;
-use hook_common::webhook;
 use hook_common::{
     pgqueue::{
         DatabaseError, Job, PgQueue, PgQueueJob, PgTransactionJob, RetryError, RetryInvalidError,


### PR DESCRIPTION
Moved from old repo.

This repo is now configured like `rusty-hook` (i.e. same branch protection and merge requirements)

Currently using the pre-existing buildjet config because I want to see everything work like it used to before changing anything.

Note that I added a `hog-rs` prefix to the images that will be built, i.e. [ghcr.io/posthog/hog-rs/capture](http://ghcr.io/posthog/hog-rs/capture) instead of [ghcr.io/posthog/capture](http://ghcr.io/posthog/capture)

This is so nothing from this repo goes to prod until we're ready. We can either remove the prefix, or keep and it change charts. I kind of like having it, because if I just saw the image name I'd have an easier time finding the repo. 🤷‍♂️ 