### PR TITLE
Fix depot build-push-action version and drop invalid builder argument

### DIFF
--- a/.github/workflows/docker-capture.yml
+++ b/.github/workflows/docker-capture.yml
@@ -54,11 +54,10 @@ jobs:
 
       - name: Build and push capture
         id: docker_build_capture
-        uses: depot/build-push-action@v4
+        uses: depot/build-push-action@v1
         with:
           context: ./
           file: ./Dockerfile
-          builder: ${{ steps.buildx.outputs.name }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-hook-api.yml
+++ b/.github/workflows/docker-hook-api.yml
@@ -54,11 +54,10 @@ jobs:
 
       - name: Build and push api
         id: docker_build_hook_api
-        uses: depot/build-push-action@v4
+        uses: depot/build-push-action@v1
         with:
           context: ./
           file: ./Dockerfile
-          builder: ${{ steps.buildx.outputs.name }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-hook-janitor.yml
+++ b/.github/workflows/docker-hook-janitor.yml
@@ -54,11 +54,10 @@ jobs:
 
       - name: Build and push janitor
         id: docker_build_hook_janitor
-        uses: depot/build-push-action@v4
+        uses: depot/build-push-action@v1
         with:
           context: ./
           file: ./Dockerfile
-          builder: ${{ steps.buildx.outputs.name }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-hook-worker.yml
+++ b/.github/workflows/docker-hook-worker.yml
@@ -54,11 +54,10 @@ jobs:
 
       - name: Build and push worker
         id: docker_build_hook_worker
-        uses: depot/build-push-action@v4
+        uses: depot/build-push-action@v1
         with:
           context: ./
           file: ./Dockerfile
-          builder: ${{ steps.buildx.outputs.name }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-migrator.yml
+++ b/.github/workflows/docker-migrator.yml
@@ -54,11 +54,10 @@ jobs:
 
       - name: Build and push migrator
         id: docker_build_hook_migrator
-        uses: depot/build-push-action@v4
+        uses: depot/build-push-action@v1
         with:
           context: ./
           file: ./Dockerfile.migrate
-          builder: ${{ steps.buildx.outputs.name }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Oops, I missed the version difference, v4 isn't valid for Depot.

`builder` gives an error, checking Depot docs with `buildx` they run `docker/setup-buildx-action@v2` but don't specify `builder`, neither does the main `posthog` repo.