### PR TITLE
Configure Actions permissions for build runs

### DIFF
--- a/.github/workflows/docker-capture.yml
+++ b/.github/workflows/docker-capture.yml
@@ -13,6 +13,11 @@ jobs:
   build:
     name: build and publish capture image
     runs-on: buildjet-4vcpu-ubuntu-2204-arm
+    permissions:
+      id-token: write # allow issuing OIDC tokens for this workflow run
+      contents: read # allow reading the repo contents
+      packages: write # allow push to ghcr.io
+
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v3

--- a/.github/workflows/docker-hook-api.yml
+++ b/.github/workflows/docker-hook-api.yml
@@ -13,6 +13,11 @@ jobs:
   build:
     name: build and publish hook-api image
     runs-on: buildjet-4vcpu-ubuntu-2204-arm
+    permissions:
+      id-token: write # allow issuing OIDC tokens for this workflow run
+      contents: read # allow reading the repo contents
+      packages: write # allow push to ghcr.io
+
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v3

--- a/.github/workflows/docker-hook-janitor.yml
+++ b/.github/workflows/docker-hook-janitor.yml
@@ -13,6 +13,11 @@ jobs:
   build:
     name: build and publish hook-janitor image
     runs-on: buildjet-4vcpu-ubuntu-2204-arm
+    permissions:
+      id-token: write # allow issuing OIDC tokens for this workflow run
+      contents: read # allow reading the repo contents
+      packages: write # allow push to ghcr.io
+
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v3

--- a/.github/workflows/docker-hook-worker.yml
+++ b/.github/workflows/docker-hook-worker.yml
@@ -13,6 +13,11 @@ jobs:
   build:
     name: build and publish hook-worker image
     runs-on: buildjet-4vcpu-ubuntu-2204-arm
+    permissions:
+      id-token: write # allow issuing OIDC tokens for this workflow run
+      contents: read # allow reading the repo contents
+      packages: write # allow push to ghcr.io
+
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v3

--- a/.github/workflows/docker-migrator.yml
+++ b/.github/workflows/docker-migrator.yml
@@ -13,6 +13,11 @@ jobs:
   build:
     name: build and publish hook-migrator image
     runs-on: buildjet-4vcpu-ubuntu-2204-arm
+    permissions:
+      id-token: write # allow issuing OIDC tokens for this workflow run
+      contents: read # allow reading the repo contents
+      packages: write # allow push to ghcr.io
+
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
`id-token` was missing for going Github OIDC auth like we do for `posthog`.