### PR TITLE
Actions docker build: change build-args to a newline delimited string

### DIFF
--- a/.github/workflows/docker-capture.yml
+++ b/.github/workflows/docker-capture.yml
@@ -69,7 +69,9 @@ jobs:
           platforms: linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: RUST_BACKTRACE=1 BIN=capture-server
+          build-args: |
+            "RUST_BACKTRACE=1"
+            "BIN=capture-server"
 
       - name: Capture image digest
         run: echo ${{ steps.docker_build_capture.outputs.digest }}

--- a/.github/workflows/docker-hook-api.yml
+++ b/.github/workflows/docker-hook-api.yml
@@ -69,7 +69,9 @@ jobs:
           platforms: linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: RUST_BACKTRACE=1 BIN=hook-api
+          build-args: |
+            "RUST_BACKTRACE=1"
+            "BIN=hook-api"
 
       - name: Hook-api image digest
         run: echo ${{ steps.docker_build_hook_api.outputs.digest }}

--- a/.github/workflows/docker-hook-janitor.yml
+++ b/.github/workflows/docker-hook-janitor.yml
@@ -69,7 +69,9 @@ jobs:
           platforms: linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: RUST_BACKTRACE=1 BIN=hook-janitor
+          build-args: |
+            "RUST_BACKTRACE=1"
+            "BIN=hook-janitor"
 
       - name: Hook-janitor image digest
         run: echo ${{ steps.docker_build_hook_janitor.outputs.digest }}

--- a/.github/workflows/docker-hook-worker.yml
+++ b/.github/workflows/docker-hook-worker.yml
@@ -69,7 +69,9 @@ jobs:
           platforms: linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: RUST_BACKTRACE=1 BIN=hook-worker
+          build-args: |
+            "RUST_BACKTRACE=1"
+            "BIN=hook-worker"
 
       - name: Hook-worker image digest
         run: echo ${{ steps.docker_build_hook_worker.outputs.digest }}


### PR DESCRIPTION
We're close. 😓 Auth is now working, but `build-args` is apparently a newline delimited string (Depot is the same): https://github.com/docker/build-push-action#inputs

I merged `capture` (which only had `RUST_BACKTRACE`) and rusty-hooks (which requires a `BIN`) incorrectly here.