### PR TITLE
Temporarily switch to a single build-args argument

### DIFF
--- a/.github/workflows/docker-capture.yml
+++ b/.github/workflows/docker-capture.yml
@@ -69,9 +69,7 @@ jobs:
           platforms: linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: |
-            "RUST_BACKTRACE=1"
-            "BIN=capture-server"
+          build-args: BIN=capture-server
 
       - name: Capture image digest
         run: echo ${{ steps.docker_build_capture.outputs.digest }}

--- a/.github/workflows/docker-hook-api.yml
+++ b/.github/workflows/docker-hook-api.yml
@@ -69,9 +69,7 @@ jobs:
           platforms: linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: |
-            "RUST_BACKTRACE=1"
-            "BIN=hook-api"
+          build-args: BIN=hook-api
 
       - name: Hook-api image digest
         run: echo ${{ steps.docker_build_hook_api.outputs.digest }}

--- a/.github/workflows/docker-hook-janitor.yml
+++ b/.github/workflows/docker-hook-janitor.yml
@@ -69,9 +69,7 @@ jobs:
           platforms: linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: |
-            "RUST_BACKTRACE=1"
-            "BIN=hook-janitor"
+          build-args: BIN=hook-janitor
 
       - name: Hook-janitor image digest
         run: echo ${{ steps.docker_build_hook_janitor.outputs.digest }}

--- a/.github/workflows/docker-hook-worker.yml
+++ b/.github/workflows/docker-hook-worker.yml
@@ -69,9 +69,7 @@ jobs:
           platforms: linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: |
-            "RUST_BACKTRACE=1"
-            "BIN=hook-worker"
+          build-args: BIN=hook-worker
 
       - name: Hook-worker image digest
         run: echo ${{ steps.docker_build_hook_worker.outputs.digest }}


### PR DESCRIPTION
The way I had it is definitely the way it works in [github/build-push-action](https://github.com/docker/build-push-action/issues/380), but I guess `depot` doesn't support this?

I verified in the Depot run that it is putting both args into the same `--build-args` (which is not what we want):

```
2024-02-07T15:30:23.6497484Z [command]/opt/hostedtoolcache/depot/2.53.0/arm64/depot build --build-arg RUST_BACKTRACE=1 BIN=hook-worker --cache-from ...
```

I'll have to bring it up with their support. For now, I'd like to get the build working. 

(Additionally, `RUST_BACKTRACE=1` came from the `capture` repo, and it's an argument to the *build*. Was `rustc` crashing for `capture` at some point? Either way, it doesn't seem strictly necessary to have in there this very second, so that I can get unblocked here.)