### PR TITLE
Fix Docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,9 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 ARG BIN
-ENV ENTRYPOINT=/usr/local/bin/$BIN
 WORKDIR /app
 
 USER nobody
 
 COPY --from=builder /app/target/release/$BIN /usr/local/bin
-ENTRYPOINT [ $ENTRYPOINT ]
+ENTRYPOINT ["/bin/sh", "-c", "/usr/local/bin/$BIN"]


### PR DESCRIPTION
While trying to debug capture I noticed this is incorrect, the `$ENTRYPOINT` isn't being expanded:

```
        "Args": [
            "-c",
            "[ $ENTRYPOINT ]",
            "--",
            "/usr/local/bin/capture-server"
        ],
```

Annoying docker magic... apparently the version in the diff _will_ expand `$BIN`.

Hooks are working because we override `command:` in the deployment.