### PR TITLE
Drop debug symbols from release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ members = [
   "hook-janitor",
 ]
 
-[profile.release]
-debug = 2 # https://www.polarsignals.com/docs/rust
+# [profile.release]
+# debug = 2 # https://www.polarsignals.com/docs/rust
 
 [workspace.dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
We aren't using these currently, and they bloat the image(s). We might again soon, so I'm just going with a comment for now.