### PR TITLE
Replace DOCKERHUB_USERNAME secret with plaintext

### DIFF
--- a/.github/workflows/docker-capture.yml
+++ b/.github/workflows/docker-capture.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: posthog
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to ghcr.io

--- a/.github/workflows/docker-hook-api.yml
+++ b/.github/workflows/docker-hook-api.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: posthog
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to ghcr.io

--- a/.github/workflows/docker-hook-janitor.yml
+++ b/.github/workflows/docker-hook-janitor.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: posthog
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to ghcr.io

--- a/.github/workflows/docker-hook-worker.yml
+++ b/.github/workflows/docker-hook-worker.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: posthog
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to ghcr.io

--- a/.github/workflows/docker-migrator.yml
+++ b/.github/workflows/docker-migrator.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: posthog
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to ghcr.io

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: posthog
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Setup dependencies


### PR DESCRIPTION
This isn't a secret and it causes every instance of "posthog" in the action logs to be replaced by "***"  because it's the value of a secret