### PR TITLE
capture: make otel service name configurable, will use deploy name

### DIFF
--- a/capture-server/tests/common.rs
+++ b/capture-server/tests/common.rs
@@ -43,6 +43,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     },
     otel_url: None,
     otel_sampling_rate: 0.0,
+    otel_service_name: "capture-testing".to_string(),
     export_prometheus: false,
 });
 

--- a/capture/src/config.rs
+++ b/capture/src/config.rs
@@ -27,6 +27,9 @@ pub struct Config {
     #[envconfig(default = "1.0")]
     pub otel_sampling_rate: f64,
 
+    #[envconfig(default = "capture")]
+    pub otel_service_name: String,
+
     #[envconfig(default = "true")]
     pub export_prometheus: bool,
 }


### PR DESCRIPTION
Make the opentelemetry service name configurable, so that we can filter traces per deploy. Will be used when we run the test deploy for traffic mirroring
