### PR TITLE
chore: add workspace-level linting config

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Run cargo check
         run: cargo check --all-features
 
-  clippy:
+  linting:
     runs-on: depot-ubuntu-22.04-4
 
     steps:
@@ -81,7 +81,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          components: clippy
+          components: clippy,rustfmt
 
       - uses: actions/cache@v3
         with:
@@ -94,17 +94,18 @@ jobs:
       - name: Run clippy
         run: cargo clippy -- -D warnings
 
-  format:
-    runs-on: depot-ubuntu-22.04-4
+      - name: Check format
+        run: cargo fmt -- --check
 
+  shear:
+    runs-on: depot-ubuntu-22.04-4
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install latest rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-          components: rustfmt
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
 
-      - name: Format
-        run: cargo fmt -- --check
+      - name: Install cargo-shear
+        run: cargo binstall --no-confirm cargo-shear
+
+      - run: cargo shear

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,12 @@ members = [
   "hook-worker",
 ]
 
+[workspace.lints.rust]
+unsafe_code = "forbid"
+
+[workspace.lints.clippy]
+enum_glob_use = "deny"
+
 [workspace.dependencies]
 anyhow = "1.0"
 assert-json-diff = "2.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,18 @@ members = [
 ]
 
 [workspace.lints.rust]
-unsafe_code = "forbid"
+# See https://doc.rust-lang.org/stable/rustc/lints/listing/allowed-by-default.html
+unsafe_code = "forbid" # forbid cannot be ignored with an annotation
+unstable_features = "forbid"
+macro_use_extern_crate = "forbid"
+let_underscore_drop = "deny"
+non_ascii_idents = "deny"
+trivial_casts = "deny"
+trivial_numeric_casts = "deny"
+unit_bindings = "deny"
 
 [workspace.lints.clippy]
+# See https://rust-lang.github.io/rust-clippy/, we might want to add more
 enum_glob_use = "deny"
 
 [workspace.dependencies]

--- a/capture-server/Cargo.toml
+++ b/capture-server/Cargo.toml
@@ -3,6 +3,9 @@ name = "capture-server"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 capture = { path = "../capture" }
 envconfig = { workspace = true }

--- a/capture/Cargo.toml
+++ b/capture/Cargo.toml
@@ -3,7 +3,8 @@ name = "capture"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [dependencies]
 anyhow = { workspace = true }

--- a/capture/src/sinks/kafka.rs
+++ b/capture/src/sinks/kafka.rs
@@ -118,10 +118,10 @@ impl KafkaSink {
             client_config.create_with_context(KafkaContext { liveness })?;
 
         // Ping the cluster to make sure we can reach brokers, fail after 10 seconds
-        _ = producer.client().fetch_metadata(
+        drop(producer.client().fetch_metadata(
             Some("__consumer_offsets"),
             Timeout::After(Duration::new(10, 0)),
-        )?;
+        )?);
         info!("connected to Kafka brokers");
 
         Ok(KafkaSink {

--- a/common/health/Cargo.toml
+++ b/common/health/Cargo.toml
@@ -3,7 +3,8 @@ name = "health"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [dependencies]
 axum = { workspace = true }

--- a/hook-api/Cargo.toml
+++ b/hook-api/Cargo.toml
@@ -3,7 +3,8 @@ name = "hook-api"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [dependencies]
 axum = { workspace = true }

--- a/hook-common/Cargo.toml
+++ b/hook-common/Cargo.toml
@@ -3,7 +3,8 @@ name = "hook-common"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [dependencies]
 async-trait = { workspace = true }

--- a/hook-janitor/Cargo.toml
+++ b/hook-janitor/Cargo.toml
@@ -3,7 +3,8 @@ name = "hook-janitor"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [dependencies]
 async-trait = { workspace = true }

--- a/hook-worker/Cargo.toml
+++ b/hook-worker/Cargo.toml
@@ -3,6 +3,9 @@ name = "hook-worker"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 axum = { workspace = true }
 chrono = { workspace = true }


### PR DESCRIPTION
- Setup linting config for the whole workspace
  - Enable several rustc lints that seem to make sense for us, happy to iterate on it
  - Clippy config is still TODO: happy to get suggestion if you have a list of additional lints to enable
- Add [cargo-shear](https://github.com/boshen/cargo-shear) to the CI to detect unused dependencies: the rustc `unused_crate_dependencies` lint has false-positives in workspaces.
- Merge clippy & format CI jobs into a single linting job (still faster than tests)