### PR TITLE
capture: don't allow events submitted with an empty distinct_id

### DIFF
--- a/capture/src/api.rs
+++ b/capture/src/api.rs
@@ -28,6 +28,8 @@ pub enum CaptureError {
     EmptyBatch,
     #[error("event submitted with an empty event name")]
     MissingEventName,
+    #[error("event submitted with an empty distinct_id")]
+    EmptyDistinctId,
     #[error("event submitted without a distinct_id")]
     MissingDistinctId,
 
@@ -59,6 +61,7 @@ impl IntoResponse for CaptureError {
             | CaptureError::RequestParsingError(_)
             | CaptureError::EmptyBatch
             | CaptureError::MissingEventName
+            | CaptureError::EmptyDistinctId
             | CaptureError::MissingDistinctId
             | CaptureError::EventTooBig
             | CaptureError::NonRetryableSinkError => (StatusCode::BAD_REQUEST, self.to_string()),


### PR DESCRIPTION
Align with [capture.py returning a invalid_distinct_id](https://github.com/PostHog/posthog/blob/d929ca9fd98570ffd808b1f8bd060b1d1433d7b2/posthog/api/capture.py#L274-L276) if a distinct_id field is present but empty.