### PR TITLE
capture: set kafka partitioner to murmur2_random

### DIFF
--- a/capture/src/sinks/kafka.rs
+++ b/capture/src/sinks/kafka.rs
@@ -96,6 +96,7 @@ impl KafkaSink {
         client_config
             .set("bootstrap.servers", &config.kafka_hosts)
             .set("statistics.interval.ms", "10000")
+            .set("partitioner", "murmur2_random") // Compatibility with python-kafka
             .set("linger.ms", config.kafka_producer_linger_ms.to_string())
             .set(
                 "message.timeout.ms",


### PR DESCRIPTION
Working on https://github.com/PostHog/posthog/pull/21850 showed a discrepancy on the message key -> partition computation between python and rust. The issue is that rdkafka's default partitionner uses CRC32, that is not supported in `python-kafka`. Let's align on python's `murmur2` partitionner (CPU overhead should be negligible).

Tested locally on a topic with 10 partitions, the same partition is used now.