### PR TITLE
capture: don't serialize sent_at if empty

### DIFF
--- a/capture/src/api.rs
+++ b/capture/src/api.rs
@@ -87,7 +87,10 @@ pub struct ProcessedEvent {
     pub ip: String,
     pub data: String,
     pub now: String,
-    #[serde(with = "time::serde::rfc3339::option", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        with = "time::serde::rfc3339::option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub sent_at: Option<OffsetDateTime>,
     pub token: String,
 }

--- a/capture/src/api.rs
+++ b/capture/src/api.rs
@@ -87,7 +87,7 @@ pub struct ProcessedEvent {
     pub ip: String,
     pub data: String,
     pub now: String,
-    #[serde(with = "time::serde::rfc3339::option")]
+    #[serde(with = "time::serde::rfc3339::option", skip_serializing_if = "Option::is_none")]
     pub sent_at: Option<OffsetDateTime>,
     pub token: String,
 }


### PR DESCRIPTION
Add the `serde` annotation to `ProcessedEvent` to not marshal the optional `sent_at` field if it is not set

Tried out locally:

<img width="2059" alt="image" src="https://github.com/PostHog/hog-rs/assets/6241083/65a9f183-eb0f-4814-92ef-517b2ff5e107">
