### PR TITLE
fix capture CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ dependencies = [
 [[package]]
 name = "axum-test-helper"
 version = "0.4.0"
-source = "git+https://github.com/orphan-rs/axum-test-helper.git#8ca0aedaad5a6bdf351c34d5b80593ae1b7d2f3f"
+source = "git+https://github.com/posthog/axum-test-helper.git#002d45d8bbbac04e6a474e9a850b7f023a87d32f"
 dependencies = [
  "axum 0.7.5",
  "bytes",

--- a/capture/Cargo.toml
+++ b/capture/Cargo.toml
@@ -38,4 +38,4 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 assert-json-diff = { workspace = true }
-axum-test-helper = { git = "https://github.com/orphan-rs/axum-test-helper.git" } # TODO: remove, directly use reqwest like capture-server tests
+axum-test-helper = { git = "https://github.com/posthog/axum-test-helper.git" } # TODO: remove, directly use reqwest like capture-server tests

--- a/capture/tests/django_compat.rs
+++ b/capture/tests/django_compat.rs
@@ -201,6 +201,11 @@ async fn it_matches_django_capture_behaviour() -> anyhow::Result<()> {
             if let Some(object) = expected.as_object_mut() {
                 // site_url is unused in the pipeline now, let's drop it
                 object.remove("site_url");
+
+                // Remove sent_at field if empty: Rust will skip marshalling it
+                if let Some(None) = object.get("sent_at").map(|v| v.as_str()) {
+                    object.remove("sent_at");
+                }
             }
 
             let match_config = assert_json_diff::Config::new(assert_json_diff::CompareMode::Strict);
@@ -209,7 +214,7 @@ async fn it_matches_django_capture_behaviour() -> anyhow::Result<()> {
             {
                 println!(
                     "record mismatch at line {}, event {}: {}",
-                    line_number, event_number, e
+                    line_number+1, event_number, e
                 );
                 mismatches += 1;
             }

--- a/capture/tests/django_compat.rs
+++ b/capture/tests/django_compat.rs
@@ -214,7 +214,9 @@ async fn it_matches_django_capture_behaviour() -> anyhow::Result<()> {
             {
                 println!(
                     "record mismatch at line {}, event {}: {}",
-                    line_number+1, event_number, e
+                    line_number + 1,
+                    event_number,
+                    e
                 );
                 mismatches += 1;
             }


### PR DESCRIPTION
- Use our own updated fork of axum-test-helper, as the one we used has been deleted. I tried moving `django_compat.rs` to the `capture-server` test harness first, but got into complications
- Fix the `sent_at` comparaison, the CI on https://github.com/PostHog/hog-rs/pull/28 should have failed 🤔 