### PR TITLE
CI: upgrade to Rust 1.77.2 and Debian bookworm

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,9 +17,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@1.77
 
       - uses: actions/cache@v3
         with:
@@ -52,9 +50,7 @@ jobs:
           echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
 
       - name: Install rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@1.77
 
       - uses: actions/cache@v3
         with:
@@ -73,10 +69,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install latest rust
-        uses: dtolnay/rust-toolchain@master
+      - name: Install rust
+        uses: dtolnay/rust-toolchain@1.77
         with:
-          toolchain: stable
           components: clippy,rustfmt
 
       - uses: actions/cache@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/lukemathwalker/cargo-chef:latest-rust-1.74.0-buster AS chef
+FROM docker.io/lukemathwalker/cargo-chef:latest-rust-1.77-bookworm AS chef
 ARG BIN
 WORKDIR /app
 
@@ -20,7 +20,7 @@ RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
 RUN cargo build --release --bin $BIN
 
-FROM debian:bullseye-20230320-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
1.78.0 just released with new clippy checks
- Use N-1 instead as a conservative move, so pin 1.77 -> will give us 1.77.2
- Bump the version in the Dockerfile too, and bump the Debian base image. Capture builds and starts
- Don't pin a specific debian build as we won't invest time in regularly bumping it outselves