### PR TITLE
hook-worker: deny traffic to internal IPs and IPv6

### DIFF
--- a/hook-worker/src/config.rs
+++ b/hook-worker/src/config.rs
@@ -37,6 +37,9 @@ pub struct Config {
 
     #[envconfig(default = "1")]
     pub dequeue_batch_size: u32,
+
+    #[envconfig(default = "false")]
+    pub allow_internal_ips: bool,
 }
 
 impl Config {

--- a/hook-worker/src/dns.rs
+++ b/hook-worker/src/dns.rs
@@ -1,0 +1,68 @@
+use std::error::Error as StdError;
+use std::io;
+use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
+
+use futures::FutureExt;
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
+use tokio::task::spawn_blocking;
+
+/// Internal reqwest type, copied here as part of Resolving
+pub(crate) type BoxError = Box<dyn StdError + Send + Sync>;
+
+/// Returns [`true`] if the address appears to be a globally reachable IPv4.
+///
+/// Trimmed down version of the unstable IpAddr::is_global, move to it when it's stable.
+fn is_global_ipv4(addr: &SocketAddr) -> bool {
+    match addr.ip() {
+        IpAddr::V4(ip) => {
+            !(ip.octets()[0] == 0 // "This network"
+            || ip.is_private()
+            || ip.is_loopback()
+            || ip.is_link_local()
+            || ip.is_broadcast())
+        }
+        IpAddr::V6(_) => false, // Our network does not currently support ipv6, let's ignore for now
+    }
+}
+
+/// DNS resolver using the stdlib resolver, but filtering results to only pass public IPv4 results.
+///
+/// Private and broadcast addresses are filtered out, so are IPv6 results for now (as our infra
+/// does not currently support IPv6 routing anyway).
+/// This is adapted from the GaiResolver in hyper and reqwest.
+pub struct PublicIPv4Resolver {}
+
+impl Resolve for PublicIPv4Resolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        // Closure to call the system's resolver (blocking call) through the ToSocketAddrs trait.
+        let resolve_host = move || (name.as_str(), 0).to_socket_addrs();
+
+        // Execute the blocking call in a separate worker thread then process its result asynchronously.
+        // spawn_blocking returns a JoinHandle that implements Future<Result<(closure result), JoinError>>.
+        let future_result = spawn_blocking(resolve_host).map(|result| match result {
+            Ok(Ok(addr)) => {
+                // Resolution succeeded, pass the IPs in a Box after filtering
+                let addrs: Addrs = Box::new(addr.filter(is_global_ipv4));
+                Ok(addrs)
+            }
+            Ok(Err(err)) => {
+                // Resolution failed, pass error through in a Box
+                let err: BoxError = Box::new(err);
+                Err(err)
+            }
+            Err(join_err) => {
+                // The tokio task failed, error handled copied from hyper's GaiResolver
+                if join_err.is_cancelled() {
+                    let err: BoxError =
+                        Box::new(io::Error::new(io::ErrorKind::Interrupted, join_err));
+                    Err(err)
+                } else {
+                    panic!("background task failed: {:?}", join_err)
+                }
+            }
+        });
+
+        // Box the Future to satisfy the Resolving interface.
+        Box::pin(future_result)
+    }
+}

--- a/hook-worker/src/dns.rs
+++ b/hook-worker/src/dns.rs
@@ -73,14 +73,9 @@ impl Resolve for PublicIPv4Resolver {
                 Err(err)
             }
             Err(join_err) => {
-                // The tokio task failed, error handled copied from hyper's GaiResolver
-                if join_err.is_cancelled() {
-                    let err: BoxError =
-                        Box::new(io::Error::new(io::ErrorKind::Interrupted, join_err));
-                    Err(err)
-                } else {
-                    panic!("background task failed: {:?}", join_err)
-                }
+                // The tokio task failed, pass as io::Error in a Box
+                let err: BoxError = Box::new(io::Error::from(join_err));
+                Err(err)
             }
         });
 

--- a/hook-worker/src/dns.rs
+++ b/hook-worker/src/dns.rs
@@ -6,15 +6,15 @@ use futures::FutureExt;
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use tokio::task::spawn_blocking;
 
-pub struct NoPublicIPError;
+pub struct NoPublicIPv4Error;
 
-impl std::error::Error for NoPublicIPError {}
-impl fmt::Display for NoPublicIPError {
+impl std::error::Error for NoPublicIPv4Error {}
+impl fmt::Display for NoPublicIPv4Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "No public IPv4 found for specified host")
     }
 }
-impl fmt::Debug for NoPublicIPError {
+impl fmt::Debug for NoPublicIPv4Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "No public IPv4 found for specified host")
     }
@@ -59,7 +59,7 @@ impl Resolve for PublicIPv4Resolver {
                 let filtered_addr: Vec<SocketAddr> = all_addrs.filter(is_global_ipv4).collect();
                 if filtered_addr.is_empty() {
                     // No public IPs found, error out with PermissionDenied
-                    let err: BoxError = Box::new(NoPublicIPError);
+                    let err: BoxError = Box::new(NoPublicIPv4Error);
                     Err(err)
                 } else {
                     // Pass remaining IPs in a boxed iterator for request to use.
@@ -91,7 +91,7 @@ impl Resolve for PublicIPv4Resolver {
 
 #[cfg(test)]
 mod tests {
-    use crate::dns::{NoPublicIPError, PublicIPv4Resolver};
+    use crate::dns::{NoPublicIPv4Error, PublicIPv4Resolver};
     use reqwest::dns::{Name, Resolve};
     use std::str::FromStr;
 
@@ -113,7 +113,7 @@ mod tests {
             .await
         {
             Ok(_) => panic!("should have failed"),
-            Err(err) => assert!(err.downcast_ref::<NoPublicIPError>().is_some()),
+            Err(err) => assert!(err.downcast_ref::<NoPublicIPv4Error>().is_some()),
         }
     }
 
@@ -122,7 +122,7 @@ mod tests {
         let resolver: PublicIPv4Resolver = PublicIPv4Resolver {};
         match resolver.resolve(Name::from_str("localhost").unwrap()).await {
             Ok(_) => panic!("should have failed"),
-            Err(err) => assert!(err.is::<NoPublicIPError>()),
+            Err(err) => assert!(err.is::<NoPublicIPv4Error>()),
         }
     }
 

--- a/hook-worker/src/dns.rs
+++ b/hook-worker/src/dns.rs
@@ -89,8 +89,10 @@ impl Resolve for PublicIPv4Resolver {
     }
 }
 
+#[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::dns::{NoPublicIPError, PublicIPv4Resolver};
+    use reqwest::dns::{Name, Resolve};
     use std::str::FromStr;
 
     #[tokio::test]

--- a/hook-worker/src/dns.rs
+++ b/hook-worker/src/dns.rs
@@ -108,7 +108,7 @@ mod tests {
             .await
         {
             Ok(_) => panic!("should have failed"),
-            Err(err) => assert!(err.downcast_ref::<NoPublicIPv4Error>().is_some()),
+            Err(err) => assert!(err.is::<NoPublicIPv4Error>()),
         }
     }
 
@@ -122,16 +122,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn it_propagates_unknown_domain() {
+    async fn it_bubbles_up_resolution_error() {
         let resolver: PublicIPv4Resolver = PublicIPv4Resolver {};
         match resolver
             .resolve(Name::from_str("invalid.domain.unknown").unwrap())
             .await
         {
             Ok(_) => panic!("should have failed"),
-            Err(err) => assert!(err
-                .to_string()
-                .contains("failed to lookup address information")),
+            Err(err) => {
+                assert!(!err.is::<NoPublicIPv4Error>());
+                assert!(err
+                    .to_string()
+                    .contains("failed to lookup address information"))
+            }
         }
     }
 }

--- a/hook-worker/src/error.rs
+++ b/hook-worker/src/error.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::fmt;
 use std::time;
 
-use crate::dns::NoPublicIPError;
+use crate::dns::NoPublicIPv4Error;
 use hook_common::{pgqueue, webhook::WebhookJobError};
 use thiserror::Error;
 
@@ -66,8 +66,8 @@ impl fmt::Display for WebhookRequestError {
                     Some(m) => m.to_string(),
                     None => "No response from the server".to_string(),
                 };
-                if is_error_source::<NoPublicIPError>(error) {
-                    writeln!(f, "{}: {}", error, NoPublicIPError)?;
+                if is_error_source::<NoPublicIPv4Error>(error) {
+                    writeln!(f, "{}: {}", error, NoPublicIPv4Error)?;
                 } else {
                     writeln!(f, "{}", error)?;
                 }
@@ -142,7 +142,7 @@ pub enum WorkerError {
 /// Check the error and it's sources (recursively) to return true if an error of the given type is found.
 /// TODO: use Error::sources() when stable
 pub fn is_error_source<T: Error + 'static>(err: &(dyn std::error::Error + 'static)) -> bool {
-    if err.is::<NoPublicIPError>() {
+    if err.is::<NoPublicIPv4Error>() {
         return true;
     }
     match err.source() {

--- a/hook-worker/src/error.rs
+++ b/hook-worker/src/error.rs
@@ -1,6 +1,8 @@
+use std::error::Error;
 use std::fmt;
 use std::time;
 
+use crate::dns::NoPublicIPError;
 use hook_common::{pgqueue, webhook::WebhookJobError};
 use thiserror::Error;
 
@@ -64,7 +66,11 @@ impl fmt::Display for WebhookRequestError {
                     Some(m) => m.to_string(),
                     None => "No response from the server".to_string(),
                 };
-                writeln!(f, "{}", error)?;
+                if is_error_source::<NoPublicIPError>(error) {
+                    writeln!(f, "{}: {}", error ,NoPublicIPError)?;
+                } else {
+                    writeln!(f, "{}", error)?;
+                }
                 write!(f, "{}", response_message)?;
 
                 Ok(())
@@ -131,4 +137,15 @@ pub enum WorkerError {
     QueueParseError(#[from] pgqueue::ParseError),
     #[error("timed out while waiting for jobs to be available")]
     TimeoutError,
+}
+
+/// Check the error and it's sources (recursively) to return true if an error of the given type is found.
+pub fn is_error_source<T: Error + 'static>(err: &(dyn std::error::Error + 'static)) -> bool {
+    if err.downcast_ref::<T>().is_some() {
+        return true;
+    }
+    match err.source() {
+        None => false,
+        Some(source) => is_error_source::<T>(source),
+    }
 }

--- a/hook-worker/src/error.rs
+++ b/hook-worker/src/error.rs
@@ -67,7 +67,7 @@ impl fmt::Display for WebhookRequestError {
                     None => "No response from the server".to_string(),
                 };
                 if is_error_source::<NoPublicIPError>(error) {
-                    writeln!(f, "{}: {}", error ,NoPublicIPError)?;
+                    writeln!(f, "{}: {}", error, NoPublicIPError)?;
                 } else {
                     writeln!(f, "{}", error)?;
                 }
@@ -140,8 +140,9 @@ pub enum WorkerError {
 }
 
 /// Check the error and it's sources (recursively) to return true if an error of the given type is found.
+/// TODO: use Error::sources() when stable
 pub fn is_error_source<T: Error + 'static>(err: &(dyn std::error::Error + 'static)) -> bool {
-    if err.downcast_ref::<T>().is_some() {
+    if err.is::<NoPublicIPError>() {
         return true;
     }
     match err.source() {

--- a/hook-worker/src/lib.rs
+++ b/hook-worker/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod dns;
 pub mod error;
 pub mod util;
 pub mod worker;

--- a/hook-worker/src/main.rs
+++ b/hook-worker/src/main.rs
@@ -52,6 +52,7 @@ async fn main() -> Result<(), WorkerError> {
         config.request_timeout.0,
         config.max_concurrent_jobs,
         retry_policy_builder.provide(),
+        config.allow_internal_ips,
         worker_liveness,
     );
 

--- a/hook-worker/src/worker.rs
+++ b/hook-worker/src/worker.rs
@@ -577,8 +577,8 @@ mod tests {
             webhook_job_parameters.clone(),
             webhook_job_metadata,
         )
-            .await
-            .expect("failed to enqueue job");
+        .await
+        .expect("failed to enqueue job");
         let worker = WebhookWorker::new(
             &worker_id,
             &queue,

--- a/hook-worker/src/worker.rs
+++ b/hook-worker/src/worker.rs
@@ -14,7 +14,7 @@ use hook_common::{
     webhook::{HttpMethod, WebhookJobError, WebhookJobMetadata, WebhookJobParameters},
 };
 use http::StatusCode;
-use reqwest::header;
+use reqwest::{header, Client};
 use tokio::sync;
 use tracing::error;
 
@@ -75,6 +75,25 @@ pub struct WebhookWorker<'p> {
     liveness: HealthHandle,
 }
 
+pub fn build_http_client(
+    request_timeout: time::Duration,
+    allow_internal_ips: bool,
+) -> reqwest::Result<Client> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        header::HeaderValue::from_static("application/json"),
+    );
+    let mut client_builder = reqwest::Client::builder()
+        .default_headers(headers)
+        .user_agent("PostHog Webhook Worker")
+        .timeout(request_timeout);
+    if !allow_internal_ips {
+        client_builder = client_builder.dns_resolver(Arc::new(PublicIPv4Resolver {}))
+    }
+    client_builder.build()
+}
+
 impl<'p> WebhookWorker<'p> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -88,21 +107,7 @@ impl<'p> WebhookWorker<'p> {
         allow_internal_ips: bool,
         liveness: HealthHandle,
     ) -> Self {
-        let mut headers = header::HeaderMap::new();
-        headers.insert(
-            header::CONTENT_TYPE,
-            header::HeaderValue::from_static("application/json"),
-        );
-
-        let mut client_builder = reqwest::Client::builder()
-            .default_headers(headers)
-            .user_agent("PostHog Webhook Worker")
-            .timeout(request_timeout);
-        if !allow_internal_ips {
-            client_builder = client_builder.dns_resolver(Arc::new(PublicIPv4Resolver {}))
-        }
-        let client = client_builder
-            .build()
+        let client = build_http_client(request_timeout, allow_internal_ips)
             .expect("failed to construct reqwest client for webhook worker");
 
         Self {
@@ -475,6 +480,7 @@ fn parse_retry_after_header(header_map: &reqwest::header::HeaderMap) -> Option<t
 
 mod tests {
     use super::*;
+    use std::time::Duration;
     // Note we are ignoring some warnings in this module.
     // This is due to a long-standing cargo bug that reports imports and helper functions as unused.
     // See: https://github.com/rust-lang/rust/issues/46379.
@@ -489,6 +495,12 @@ mod tests {
     #[allow(dead_code)]
     fn worker_id() -> String {
         std::process::id().to_string()
+    }
+
+    /// Get a request client or panic
+    #[allow(dead_code)]
+    fn localhost_client() -> Client {
+        build_http_client(Duration::from_secs(1), true).expect("failed to create client")
     }
 
     #[allow(dead_code)]
@@ -565,8 +577,8 @@ mod tests {
             webhook_job_parameters.clone(),
             webhook_job_metadata,
         )
-        .await
-        .expect("failed to enqueue job");
+            .await
+            .expect("failed to enqueue job");
         let worker = WebhookWorker::new(
             &worker_id,
             &queue,
@@ -601,15 +613,14 @@ mod tests {
         assert!(registry.get_status().healthy)
     }
 
-    #[sqlx::test(migrations = "../migrations")]
-    async fn test_send_webhook(_pg: PgPool) {
+    #[tokio::test]
+    async fn test_send_webhook() {
         let method = HttpMethod::POST;
         let url = "http://localhost:18081/echo";
         let headers = collections::HashMap::new();
         let body = "a very relevant request body";
-        let client = reqwest::Client::new();
 
-        let response = send_webhook(client, &method, url, &headers, body.to_owned())
+        let response = send_webhook(localhost_client(), &method, url, &headers, body.to_owned())
             .await
             .expect("send_webhook failed");
 
@@ -620,15 +631,14 @@ mod tests {
         );
     }
 
-    #[sqlx::test(migrations = "../migrations")]
-    async fn test_error_message_contains_response_body(_pg: PgPool) {
+    #[tokio::test]
+    async fn test_error_message_contains_response_body() {
         let method = HttpMethod::POST;
         let url = "http://localhost:18081/fail";
         let headers = collections::HashMap::new();
         let body = "this is an error message";
-        let client = reqwest::Client::new();
 
-        let err = send_webhook(client, &method, url, &headers, body.to_owned())
+        let err = send_webhook(localhost_client(), &method, url, &headers, body.to_owned())
             .await
             .err()
             .expect("request didn't fail when it should have failed");
@@ -645,17 +655,16 @@ mod tests {
         }
     }
 
-    #[sqlx::test(migrations = "../migrations")]
-    async fn test_error_message_contains_up_to_n_bytes_of_response_body(_pg: PgPool) {
+    #[tokio::test]
+    async fn test_error_message_contains_up_to_n_bytes_of_response_body() {
         let method = HttpMethod::POST;
         let url = "http://localhost:18081/fail";
         let headers = collections::HashMap::new();
         // This is double the current hardcoded amount of bytes.
         // TODO: Make this configurable and change it here too.
         let body = (0..20 * 1024).map(|_| "a").collect::<Vec<_>>().concat();
-        let client = reqwest::Client::new();
 
-        let err = send_webhook(client, &method, url, &headers, body.to_owned())
+        let err = send_webhook(localhost_client(), &method, url, &headers, body.to_owned())
             .await
             .err()
             .expect("request didn't fail when it should have failed");
@@ -671,6 +680,31 @@ mod tests {
             assert!(request_error.to_string().contains(
                 "HTTP status client error (400 Bad Request) for url (http://localhost:18081/fail)"
             ));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_private_ips_denied() {
+        let method = HttpMethod::POST;
+        let url = "http://localhost:18081/echo";
+        let headers = collections::HashMap::new();
+        let body = "a very relevant request body";
+        let filtering_client =
+            build_http_client(Duration::from_secs(1), false).expect("failed to create client");
+
+        let err = send_webhook(filtering_client, &method, url, &headers, body.to_owned())
+            .await
+            .err()
+            .expect("request didn't fail when it should have failed");
+
+        assert!(matches!(err, WebhookError::Request(..)));
+        if let WebhookError::Request(request_error) = err {
+            assert_eq!(request_error.status(), None);
+            assert!(request_error
+                .to_string()
+                .contains("No public IPv4 found for specified host"));
+        } else {
+            panic!("unexpected error type {:?}", err)
         }
     }
 }


### PR DESCRIPTION
Make sure that requests to our internal systems cannot be executed through the hook delivery system. In order to be resilient to DNS rebinding attacks, we need to insert our validation logic between the DNS resolution and the HTTP request execution. In this PR, I am wrapping reqwest's `Resolving` interface to intercept and validate the IPs returned by the system's DNS resolver.

- Add `PublicIPv4Resolver`, that copies hyper's `GaiResolver` logic + filtering of the results via `is_global_ipv4`
  - It removes non-public IPs from the resolution results, to make sure that we don't request internal hosts. Since our infra is currently IPv4-only and unable to contact IPv6 destinations, we just filter out all IPv6 addresses for now. We'll implement non-public IPv6 filtering when needed
  - It returns a `NoPublicIPv4Error` if the filtered lists is empty, making sure we don't get hard to diagnose "network unreachable" errors. Make sure that this error is surfaced in logs
- Add tests for the resolver + the worker itself