### PR TITLE
Make max_body_size configurable via env, drop custom check, use 413

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,6 +1076,7 @@ dependencies = [
  "sqlx",
  "tokio",
  "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 
 [workspace.lints.rust]
 # See https://doc.rust-lang.org/stable/rustc/lints/listing/allowed-by-default.html
-unsafe_code = "forbid" # forbid cannot be ignored with an annotation
+unsafe_code = "forbid"            # forbid cannot be ignored with an annotation
 unstable_features = "forbid"
 macro_use_extern_crate = "forbid"
 let_underscore_drop = "deny"
@@ -69,7 +69,7 @@ time = { version = "0.3.20", features = [
 thiserror = { version = "1.0" }
 tokio = { version = "1.34.0", features = ["full"] }
 tower = "0.4.13"
-tower-http = { version = "0.5.2", features = ["cors", "trace"] }
+tower-http = { version = "0.5.2", features = ["cors", "limit", "trace"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 url = { version = "2.5.0 " }

--- a/hook-api/Cargo.toml
+++ b/hook-api/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }
+tower-http = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }

--- a/hook-api/src/config.rs
+++ b/hook-api/src/config.rs
@@ -16,6 +16,9 @@ pub struct Config {
 
     #[envconfig(default = "100")]
     pub max_pg_connections: u32,
+
+    #[envconfig(default = "5000000")]
+    pub max_body_size: usize,
 }
 
 impl Config {

--- a/hook-api/src/handlers/app.rs
+++ b/hook-api/src/handlers/app.rs
@@ -1,10 +1,11 @@
-use axum::{extract::DefaultBodyLimit, routing, Router};
+use axum::{routing, Router};
+use tower_http::limit::RequestBodyLimitLayer;
 
 use hook_common::pgqueue::PgQueue;
 
 use super::webhook;
 
-pub fn add_routes(router: Router, pg_pool: PgQueue) -> Router {
+pub fn add_routes(router: Router, pg_pool: PgQueue, max_body_size: usize) -> Router {
     router
         .route("/", routing::get(index))
         .route("/_readiness", routing::get(index))
@@ -13,7 +14,7 @@ pub fn add_routes(router: Router, pg_pool: PgQueue) -> Router {
             "/webhook",
             routing::post(webhook::post)
                 .with_state(pg_pool)
-                .layer(DefaultBodyLimit::disable()),
+                .layer(RequestBodyLimitLayer::new(max_body_size)),
         )
 }
 
@@ -37,7 +38,7 @@ mod tests {
     async fn index(db: PgPool) {
         let pg_queue = PgQueue::new_from_pool("test_index", db).await;
 
-        let app = add_routes(Router::new(), pg_queue);
+        let app = add_routes(Router::new(), pg_queue, 1_000_000);
 
         let response = app
             .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())

--- a/hook-api/src/main.rs
+++ b/hook-api/src/main.rs
@@ -34,7 +34,7 @@ async fn main() {
     .await
     .expect("failed to initialize queue");
 
-    let app = handlers::add_routes(Router::new(), pg_queue);
+    let app = handlers::add_routes(Router::new(), pg_queue, config.max_body_size);
     let app = setup_metrics_routes(app);
 
     match listen(app, config.bind()).await {


### PR DESCRIPTION
I didn't know Axum had its own default limit until today, this cleans up the hack made here https://github.com/PostHog/hog-rs/commit/cf9b82d97d6a453506560f96a625f4758bd6223a and leans into their limiter and makes it more easily configurable.