### PR TITLE
capture: fix produce_rtt_latency metric unit

### DIFF
--- a/capture/src/sinks/kafka.rs
+++ b/capture/src/sinks/kafka.rs
@@ -50,19 +50,19 @@ impl rdkafka::ClientContext for KafkaContext {
             let id_string = format!("{}", stats.nodeid);
             if let Some(rtt) = stats.rtt {
                 gauge!(
-                    "capture_kafka_produce_rtt_latency_ms",
+                    "capture_kafka_produce_rtt_latency_us",
                     "quantile" => "p50",
                     "broker" => id_string.clone()
                 )
                 .set(rtt.p50 as f64);
                 gauge!(
-                    "capture_kafka_produce_rtt_latency_ms",
+                    "capture_kafka_produce_rtt_latency_us",
                     "quantile" => "p90",
                     "broker" => id_string.clone()
                 )
                 .set(rtt.p90 as f64);
                 gauge!(
-                    "capture_kafka_produce_rtt_latency_ms",
+                    "capture_kafka_produce_rtt_latency_us",
                     "quantile" => "p95",
                     "broker" => id_string.clone()
                 )

--- a/capture/src/sinks/kafka.rs
+++ b/capture/src/sinks/kafka.rs
@@ -68,7 +68,7 @@ impl rdkafka::ClientContext for KafkaContext {
                 )
                 .set(rtt.p95 as f64);
                 gauge!(
-                    "capture_kafka_produce_rtt_latency_ms",
+                    "capture_kafka_produce_rtt_latency_us",
                     "quantile" => "p99",
                     "broker" => id_string.clone()
                 )


### PR DESCRIPTION
The latency is reported in *microseconds* and not *milliseconds*. Let's make the metric name reflect this to avoid surprises when querying 🤷 